### PR TITLE
Better behavior when no content is found

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ options:
   --fan                 set machine fan on
   -V, --version         show version number and exit
 ```
+
+You can also store those settings in `~/.config/svg2gcode.toml`, eg:
+
+```
+xmaxtravel= 400
+ymaxtravel= 400
+imagespeed = 6000
+```
+
+It can be used with any parameter which takes a value, and alows to persist your laser settings.
+
 ### Notes:
   - example command to create two types of gcode file, one containing the drawings of the .svg, the other containing the images:      
 ```

--- a/svg2gcode/__main__.py
+++ b/svg2gcode/__main__.py
@@ -18,12 +18,22 @@ def svg2gcode(args) -> int:
     """
     image2gcode: convert svg to gcode
     """
+    p = {'laser_power':args.cuttingpower,
+         'movement_speed':args.cuttingspeed,
+         'pixel_size':args.pixelsize,
+
+         'maximum_image_laser_power':args.imagepower,
+         'image_movement_speed':args.imagespeed,
+         'fan':args.fan,
+         'rapid_move':args.rapidmove,
+
+         'showimage':args.showimage,
+         'x_axis_maximum_travel':args.xmaxtravel,
+         'y_axis_maximum_travel':args.ymaxtravel}
     try:
         # Instantiate a compiler, specifying the interface type and the speed at which the tool should move (for both image drawings and laser cutting).
         # For line drawings 'pass_depth' controls how far down the tool moves after every pass. Set it to 0 if your machine does not support Z axis movement.
-        gcode_compiler = Compiler(interfaces.Gcode, params={'laser_power':args.cuttingpower,'movement_speed':args.cuttingspeed, 'pixel_size':args.pixelsize,
-                        'maximum_image_laser_power':args.imagepower, 'image_movement_speed':args.imagespeed, 'fan':args.fan,'rapid_move':args.rapidmove,
-                        'showimage':args.showimage, 'x_axis_maximum_travel':args.xmaxtravel,'y_axis_maximum_travel':args.ymaxtravel})
+        gcode_compiler = Compiler(interfaces.Gcode, params=p)
         # emit gcode for svg
         gcode_compiler.compile_to_file(args.gcode, parse_file(args.svg), passes=1)
 

--- a/svg2gcode/__main__.py
+++ b/svg2gcode/__main__.py
@@ -53,7 +53,6 @@ def main() -> int:
     cuttingspeed_default = 1000
     imagepower_default = 300
     cuttingpower_default = 850
-    laserpower_default = 1000
     xmaxtravel_default = 300
     ymaxtravel_default = 400
 

--- a/svg2gcode/__main__.py
+++ b/svg2gcode/__main__.py
@@ -29,6 +29,8 @@ def svg2gcode(args) -> int:
          'fan':args.fan,
          'rapid_move':args.rapidmove,
 
+         'laser_mode': args.mode,
+
          'monochrome': args.monochrome,
          'showimage':args.showimage,
          'x_axis_maximum_travel':args.xmaxtravel,
@@ -58,6 +60,7 @@ def main() -> int:
         "cuttingspeed" : 1000,
         "imagepower" : 300,
         "cuttingpower" : 850,
+        "mode": 'dynamic',
         "xmaxtravel" : 300,
         "ymaxtravel" : 400,
     }
@@ -92,6 +95,7 @@ def main() -> int:
     parser.add_argument('--ymaxtravel', default=defaults["ymaxtravel"], metavar=getMetaStr("ymaxtravel"),
         type=int, help="machine y-axis lengh in mm")
     parser.add_argument('--fan', action='store_true', default=False, help='set machine fan on' )
+    parser.add_argument('--mode', default=defaults["mode"], help='Set laser mode to dynamic or constant', metavar=getMetaStr("mode") )
     parser.add_argument('-V', '--version', action='version', version='%(prog)s ' + __version__, help="show version number and exit")
 
     args = parser.parse_args()

--- a/svg2gcode/__main__.py
+++ b/svg2gcode/__main__.py
@@ -66,26 +66,30 @@ def main() -> int:
         with open(config_file, 'rb') as f:
             defaults.update(tomllib.load(f).items())
 
+    def getMetaStr(v):
+        "Returns annotations on a variable"
+        return f"<default: {defaults[v]}>"
+
     # Define command line argument interface
     parser = argparse.ArgumentParser(description='Convert svg to gcode for GRBL v1.1 compatible diode laser engravers.')
     parser.add_argument('svg', type=str, help='svg file to be converted to gcode')
     parser.add_argument('gcode', type=str, help='gcode output file')
     parser.add_argument('--showimage', action='store_true', default=False, help='show b&w converted image' )
     parser.add_argument('--monochrome', action='store_true', default=False, help='Convert to pure black and white' )
-    parser.add_argument('--pixelsize', default=defaults["pixelsize"], metavar="<default:" + str(defaults["pixelsize"])+">",
+    parser.add_argument('--pixelsize', default=defaults["pixelsize"], metavar=getMetaStr("pixelsize"),
         type=float, help="pixel size in mm (XY-axis): each image pixel is drawn this size")
-    parser.add_argument('--imagespeed', default=defaults["imagespeed"], metavar="<default:" + str(defaults["imagespeed"])+">",
+    parser.add_argument('--imagespeed', default=defaults["imagespeed"], metavar=getMetaStr("imagespeed"),
         type=int, help='image draw speed in mm/min')
-    parser.add_argument('--cuttingspeed', default=defaults["cuttingspeed"], metavar="<default:" + str(defaults["cuttingspeed"])+">",
+    parser.add_argument('--cuttingspeed', default=defaults["cuttingspeed"], metavar=getMetaStr("cuttingspeed"),
         type=int, help='cutting speed in mm/min')
-    parser.add_argument('--imagepower', default=defaults["imagepower"], metavar="<default:" +str(defaults["imagepower"])+ ">",
+    parser.add_argument('--imagepower', default=defaults["imagepower"], metavar=getMetaStr("imagepower"),
         type=int, help="maximum laser power while drawing an image (as a rule of thumb set to 1/3 of the machine maximum)")
-    parser.add_argument('--cuttingpower', default=defaults["cuttingpower"], metavar="<default:" +str(defaults["cuttingpower"])+ ">",
+    parser.add_argument('--cuttingpower', default=defaults["cuttingpower"], metavar=getMetaStr("cuttingpower"),
         type=int, help="sets laser power of line drawings/cutting")
     parser.add_argument('--rapidmove', action='store_true', default=True, help='generate inbetween G0 moves' )
-    parser.add_argument('--xmaxtravel', default=defaults["xmaxtravel"], metavar="<default:" +str(defaults["xmaxtravel"])+ ">",
+    parser.add_argument('--xmaxtravel', default=defaults["xmaxtravel"], metavar=getMetaStr("xmaxtravel"),
         type=int, help="machine x-axis lengh in mm")
-    parser.add_argument('--ymaxtravel', default=defaults["ymaxtravel"], metavar="<default:" +str(defaults["ymaxtravel"])+ ">",
+    parser.add_argument('--ymaxtravel', default=defaults["ymaxtravel"], metavar=getMetaStr("ymaxtravel"),
         type=int, help="machine y-axis lengh in mm")
     parser.add_argument('--fan', action='store_true', default=False, help='set machine fan on' )
     parser.add_argument('-V', '--version', action='version', version='%(prog)s ' + __version__, help="show version number and exit")

--- a/svg2gcode/__main__.py
+++ b/svg2gcode/__main__.py
@@ -27,6 +27,7 @@ def svg2gcode(args) -> int:
          'fan':args.fan,
          'rapid_move':args.rapidmove,
 
+         'monochrome': args.monochrome,
          'showimage':args.showimage,
          'x_axis_maximum_travel':args.xmaxtravel,
          'y_axis_maximum_travel':args.ymaxtravel}
@@ -61,6 +62,7 @@ def main() -> int:
     parser.add_argument('svg', type=str, help='svg file to be converted to gcode')
     parser.add_argument('gcode', type=str, help='gcode output file')
     parser.add_argument('--showimage', action='store_true', default=False, help='show b&w converted image' )
+    parser.add_argument('--monochrome', action='store_true', default=False, help='Convert to pure black and white' )
     parser.add_argument('--pixelsize', default=pixelsize_default, metavar="<default:" + str(pixelsize_default)+">",
         type=float, help="pixel size in mm (XY-axis): each image pixel is drawn this size")
     parser.add_argument('--imagespeed', default=imagespeed_default, metavar="<default:" + str(imagespeed_default)+">",

--- a/svg2gcode/__main__.py
+++ b/svg2gcode/__main__.py
@@ -2,7 +2,9 @@
 svg2gcode: convert an image to gcode.
 """
 
+import os
 import sys
+import tomllib
 import argparse
 
 from svg2gcode.svg_to_gcode.svg_parser import parse_file
@@ -48,14 +50,23 @@ def main() -> int:
     """
     main
     """
+    config_file = os.path.expanduser('~/.config/svg2gcode.toml')
+
     # defaults
-    pixelsize_default = 0.1
-    imagespeed_default = 800
-    cuttingspeed_default = 1000
-    imagepower_default = 300
-    cuttingpower_default = 850
-    xmaxtravel_default = 300
-    ymaxtravel_default = 400
+    cfg = {
+        "pixelsize_default" : 0.1,
+        "imagespeed_default" : 800,
+        "cuttingspeed_default" : 1000,
+        "imagepower_default" : 300,
+        "cuttingpower_default" : 850,
+        "xmaxtravel_default" : 300,
+        "ymaxtravel_default" : 400,
+    }
+
+    if os.path.exists(config_file):
+        with open(config_file, 'rb') as f:
+            cfg.update({k + '_default': v for k,v in tomllib.load(f).items()})
+
 
     # Define command line argument interface
     parser = argparse.ArgumentParser(description='Convert svg to gcode for GRBL v1.1 compatible diode laser engravers.')
@@ -63,20 +74,20 @@ def main() -> int:
     parser.add_argument('gcode', type=str, help='gcode output file')
     parser.add_argument('--showimage', action='store_true', default=False, help='show b&w converted image' )
     parser.add_argument('--monochrome', action='store_true', default=False, help='Convert to pure black and white' )
-    parser.add_argument('--pixelsize', default=pixelsize_default, metavar="<default:" + str(pixelsize_default)+">",
+    parser.add_argument('--pixelsize', default=cfg["pixelsize_default"], metavar="<default:" + str(cfg["pixelsize_default"])+">",
         type=float, help="pixel size in mm (XY-axis): each image pixel is drawn this size")
-    parser.add_argument('--imagespeed', default=imagespeed_default, metavar="<default:" + str(imagespeed_default)+">",
+    parser.add_argument('--imagespeed', default=cfg["imagespeed_default"], metavar="<default:" + str(cfg["imagespeed_default"])+">",
         type=int, help='image draw speed in mm/min')
-    parser.add_argument('--cuttingspeed', default=cuttingspeed_default, metavar="<default:" + str(cuttingspeed_default)+">",
+    parser.add_argument('--cuttingspeed', default=cfg["cuttingspeed_default"], metavar="<default:" + str(cfg["cuttingspeed_default"])+">",
         type=int, help='cutting speed in mm/min')
-    parser.add_argument('--imagepower', default=imagepower_default, metavar="<default:" +str(imagepower_default)+ ">",
+    parser.add_argument('--imagepower', default=cfg["imagepower_default"], metavar="<default:" +str(cfg["imagepower_default"])+ ">",
         type=int, help="maximum laser power while drawing an image (as a rule of thumb set to 1/3 of the machine maximum)")
-    parser.add_argument('--cuttingpower', default=cuttingpower_default, metavar="<default:" +str(cuttingpower_default)+ ">",
+    parser.add_argument('--cuttingpower', default=cfg["cuttingpower_default"], metavar="<default:" +str(cfg["cuttingpower_default"])+ ">",
         type=int, help="sets laser power of line drawings/cutting")
     parser.add_argument('--rapidmove', action='store_true', default=True, help='generate inbetween G0 moves' )
-    parser.add_argument('--xmaxtravel', default=xmaxtravel_default, metavar="<default:" +str(xmaxtravel_default)+ ">",
+    parser.add_argument('--xmaxtravel', default=cfg["xmaxtravel_default"], metavar="<default:" +str(cfg["xmaxtravel_default"])+ ">",
         type=int, help="machine x-axis lengh in mm")
-    parser.add_argument('--ymaxtravel', default=ymaxtravel_default, metavar="<default:" +str(ymaxtravel_default)+ ">",
+    parser.add_argument('--ymaxtravel', default=cfg["ymaxtravel_default"], metavar="<default:" +str(cfg["ymaxtravel_default"])+ ">",
         type=int, help="machine y-axis lengh in mm")
     parser.add_argument('--fan', action='store_true', default=False, help='set machine fan on' )
     parser.add_argument('-V', '--version', action='version', version='%(prog)s ' + __version__, help="show version number and exit")

--- a/svg2gcode/__main__.py
+++ b/svg2gcode/__main__.py
@@ -52,21 +52,19 @@ def main() -> int:
     """
     config_file = os.path.expanduser('~/.config/svg2gcode.toml')
 
-    # defaults
-    cfg = {
-        "pixelsize_default" : 0.1,
-        "imagespeed_default" : 800,
-        "cuttingspeed_default" : 1000,
-        "imagepower_default" : 300,
-        "cuttingpower_default" : 850,
-        "xmaxtravel_default" : 300,
-        "ymaxtravel_default" : 400,
+    defaults = {
+        "pixelsize" : 0.1,
+        "imagespeed" : 800,
+        "cuttingspeed" : 1000,
+        "imagepower" : 300,
+        "cuttingpower" : 850,
+        "xmaxtravel" : 300,
+        "ymaxtravel" : 400,
     }
 
     if os.path.exists(config_file):
         with open(config_file, 'rb') as f:
-            cfg.update({k + '_default': v for k,v in tomllib.load(f).items()})
-
+            defaults.update(tomllib.load(f).items())
 
     # Define command line argument interface
     parser = argparse.ArgumentParser(description='Convert svg to gcode for GRBL v1.1 compatible diode laser engravers.')
@@ -74,20 +72,20 @@ def main() -> int:
     parser.add_argument('gcode', type=str, help='gcode output file')
     parser.add_argument('--showimage', action='store_true', default=False, help='show b&w converted image' )
     parser.add_argument('--monochrome', action='store_true', default=False, help='Convert to pure black and white' )
-    parser.add_argument('--pixelsize', default=cfg["pixelsize_default"], metavar="<default:" + str(cfg["pixelsize_default"])+">",
+    parser.add_argument('--pixelsize', default=defaults["pixelsize"], metavar="<default:" + str(defaults["pixelsize"])+">",
         type=float, help="pixel size in mm (XY-axis): each image pixel is drawn this size")
-    parser.add_argument('--imagespeed', default=cfg["imagespeed_default"], metavar="<default:" + str(cfg["imagespeed_default"])+">",
+    parser.add_argument('--imagespeed', default=defaults["imagespeed"], metavar="<default:" + str(defaults["imagespeed"])+">",
         type=int, help='image draw speed in mm/min')
-    parser.add_argument('--cuttingspeed', default=cfg["cuttingspeed_default"], metavar="<default:" + str(cfg["cuttingspeed_default"])+">",
+    parser.add_argument('--cuttingspeed', default=defaults["cuttingspeed"], metavar="<default:" + str(defaults["cuttingspeed"])+">",
         type=int, help='cutting speed in mm/min')
-    parser.add_argument('--imagepower', default=cfg["imagepower_default"], metavar="<default:" +str(cfg["imagepower_default"])+ ">",
+    parser.add_argument('--imagepower', default=defaults["imagepower"], metavar="<default:" +str(defaults["imagepower"])+ ">",
         type=int, help="maximum laser power while drawing an image (as a rule of thumb set to 1/3 of the machine maximum)")
-    parser.add_argument('--cuttingpower', default=cfg["cuttingpower_default"], metavar="<default:" +str(cfg["cuttingpower_default"])+ ">",
+    parser.add_argument('--cuttingpower', default=defaults["cuttingpower"], metavar="<default:" +str(defaults["cuttingpower"])+ ">",
         type=int, help="sets laser power of line drawings/cutting")
     parser.add_argument('--rapidmove', action='store_true', default=True, help='generate inbetween G0 moves' )
-    parser.add_argument('--xmaxtravel', default=cfg["xmaxtravel_default"], metavar="<default:" +str(cfg["xmaxtravel_default"])+ ">",
+    parser.add_argument('--xmaxtravel', default=defaults["xmaxtravel"], metavar="<default:" +str(defaults["xmaxtravel"])+ ">",
         type=int, help="machine x-axis lengh in mm")
-    parser.add_argument('--ymaxtravel', default=cfg["ymaxtravel_default"], metavar="<default:" +str(cfg["ymaxtravel_default"])+ ">",
+    parser.add_argument('--ymaxtravel', default=defaults["ymaxtravel"], metavar="<default:" +str(defaults["ymaxtravel"])+ ">",
         type=int, help="machine y-axis lengh in mm")
     parser.add_argument('--fan', action='store_true', default=False, help='set machine fan on' )
     parser.add_argument('-V', '--version', action='version', version='%(prog)s ' + __version__, help="show version number and exit")

--- a/svg2gcode/svg_to_gcode/__init__.py
+++ b/svg2gcode/svg_to_gcode/__init__.py
@@ -30,7 +30,8 @@ SETTING 	= {
     "rapid_move",		# boolean		when false, do not use rapid move (G0) to go to the next line chain, use a 'slow' (G1) move with laser
 				# 			power off (S0) (note that the first move - to the start of the first line chain - is still a rapid move)
     "pixel_size",               # float                 sets image pixel size (in mm)
-    "showimage"                 # boolean               show image used for conversion to gcode
+    "showimage",                 # boolean               show image used for conversion to gcode
+    "monochrome"                # boolean       converts to dithered pure black and white
 }
 
 # Set defaults 'minimum_laser_power', 'pass_depth', 'dwell_time', 'laser_power', 'laser_mode', 'unit', 'distance_mode'
@@ -57,7 +58,8 @@ DEFAULT_SETTING 	= {
     "distance_mode": 		"absolute",	# default set to absolute
     "rapid_move":		True,		# default set to true
     "pixel_size":               0.1,            # laser kerf is mostly < 0.1mm
-    "showimage":                False           # default image is not shown
+    "showimage":                False,           # default image is not shown
+    "monochrome":                False           # default allows grey levels / intermediate shades
 }
 
 def check_setting(setting: dict[str,Any] =None) -> bool:

--- a/svg2gcode/svg_to_gcode/__init__.py
+++ b/svg2gcode/svg_to_gcode/__init__.py
@@ -6,7 +6,6 @@ LASERMODE	= {"constant", "dynamic"}
 DISTANCEMODE 	= {"absolute", "incremental"}
 SETTING 	= {
     # Machine parameters
-    "laser_mode_enable", 	# boolean 		sets grlb 1.1 laser mode (set default on most laser cutters)
     "minimum_laser_power",	# positive integer	sets lowest power value for laser (NOTE: currently unused)
     "maximum_laser_power",	# positive integer	sets highest power value for laser (NOTE: currently unused)
     "x_axis_maximum_rate",	# positive integer	maximum X-axis speed (typically mm/sec or mm/min) (NOTE: currently unused)
@@ -37,7 +36,6 @@ SETTING 	= {
 # Set defaults 'minimum_laser_power', 'pass_depth', 'dwell_time', 'laser_power', 'laser_mode', 'unit', 'distance_mode'
 DEFAULT_SETTING 	= {
     # Machine parameters
-    "laser_mode_enable": 	None,		# usually already on
     "minimum_laser_power": 	0,		# default set to 0
     "maximum_laser_power": 	None,		# MANDATORY ('enter $$' on the machine console to get this - and other machine parameters)
     "x_axis_maximum_rate": 	None,		# currently unused
@@ -82,8 +80,6 @@ def check_setting(setting: dict[str,Any] =None) -> bool:
         if key not in SETTING:
             raise ValueError(f"Unknown setting {key}. Please specify one of the following: {SETTING}")
         # Machine parameters
-        if key == "laser_mode_enable" and setting[key] not in {True,False}:
-            raise ValueError(f"Unknown '{key}' value '{setting[key]}'. Please specify one of the following: {{True,False}}")
         if key in {"minimum_laser_power","maximum_laser_power","x_axis_maximum_rate","y_axis_maximum_rate", "movement_speed",
                    "x_axis_maximum_travel","y_axis_maximum_travel", "maximum_image_laser_power",
                    "image_movement_speed","laser_power" } and (not isinstance(setting[key],int) or setting[key] < 0):

--- a/svg2gcode/svg_to_gcode/compiler/_compiler.py
+++ b/svg2gcode/svg_to_gcode/compiler/_compiler.py
@@ -131,7 +131,7 @@ class Compiler:
         Assembles the code in the header, body and footer.
         """
 
-        header_gc = ["M5","M8", "M4"]
+        header_gc = ["M5","M8", "M4" if self.settings['laser_mode'] == 'dynamic' else "M3"]
         # laser off, fan off, program stop
         footer_gc = ["M5","M9","M2"]
 

--- a/svg2gcode/svg_to_gcode/compiler/_compiler.py
+++ b/svg2gcode/svg_to_gcode/compiler/_compiler.py
@@ -265,7 +265,7 @@ class Compiler:
 
             # convert to B&W without alpha
             #img = img.convert("LA")
-            img = img.convert("L")
+            img = img.convert("1" if self.settings["monochrome"] else "L")
             if self.settings['showimage']:
                 img.show()
 


### PR DESCRIPTION
- same behavior for both files when there is no content (always avoid generating empty files)
- use `logging` for logs (instead of `warnings`)/ rework some messages